### PR TITLE
draft: refactor readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
 # TEAM ZOMBIE MINECRAFT MOD / COMP5541 Winter 2022
 
-## MOD DESCRIPTION & INFORMATION
+## Description
 
-The idea of this mod is to bring into the world the items and functionalities of the Pokemon world. Items like pokemon balls and functionality like catching and releasing pokemon. 
+The idea of this mod is to implement some items and functionalities of the Pokémon game. These include items such as Poké Balls, and functionalities such as catching and releasing Pokémons.
 
+## Background
 
-### MINECRAFT
+This project is bootstrapped from Forge's MDK 1.18.1-39.0.59, which can be found [here](https://adfoc.us/serve/sitelinks/?id=271228&url=https://maven.minecraftforge.net/net/minecraftforge/forge/1.18.1-39.0.59/forge-1.18.1-39.0.59-mdk.zip).
 
-This mod is developped around Minecraft version 1.18.1
+## Development
 
-### FORGE
+### Requirements
 
-This mod is built using *forge* version 39.0.59
-[Installer](https://adfoc.us/serve/sitelinks/?id=271228&url=https://maven.minecraftforge.net/net/minecraftforge/forge/1.18.1-39.0.59/forge-1.18.1-39.0.59-installer.jar) & [MDK](https://adfoc.us/serve/sitelinks/?id=271228&url=https://maven.minecraftforge.net/net/minecraftforge/forge/1.18.1-39.0.59/forge-1.18.1-39.0.59-mdk.zip)
+#### IDE (IntelliJ IDEA)
 
+_(windows)_
 
-## INSTALLATION
+The following powershell command in will install the intelliJ IDEA silently: 
 
-Step 1: Open your command-line and browse to the folder where you extracted the zip file.
+```powershell
+$ideaIC="ideaIC-2021.3.2.exe"; (New-Object System.Net.WebClient).DownloadFile("https://download.jetbrains.com/idea/${ideaIC}", "${PWD}/${ideaIC}"); Start-Process "${PWD}/${ideaIC}" -ArgumentList "/S"
+```
 
-Step 2: You're left with a choice.
+It is also possible to download the [installer](https://download.jetbrains.com/idea/ideaIC-2021.3.2.exe) and install manually.
 
-If you prefer to use Eclipse:
-1. Run the following command: `gradlew genEclipseRuns` (`./gradlew genEclipseRuns` if you are on Mac/Linux)
-2. Open Eclipse, Import > Existing Gradle Project > Select Folder 
-   or run `gradlew eclipse` to generate the project.
- 
-*Notes: Use can also skip step 1 and simply run the gradle task `genEclipseRuns` once the gradle project has properly been imported into eclipse.
+_(macos)_
 
-If you prefer to use IntelliJ:
-1. Open IDEA, and import project.
-2. Select your build.gradle file and have it import.
-3. Run the following command: `gradlew genIntellijRuns` (`./gradlew genIntellijRuns` if you are on Mac/Linux)
-4. Refresh the Gradle Project in IDEA if required.
+Download the [installer](https://download.jetbrains.com/idea/ideaIC-2021.3.2.dmg) and install manually.
+
+## First run
+
+Launch the gradle task `runClient` from the IDE. See IntelliJ IDEA's [documentation](https://www.jetbrains.com/help/idea/work-with-gradle-tasks.html) about gradle integrations. 
+
+_TLDR: Open the [**Gradle** tool window](https://www.jetbrains.com/help/idea/jetgradle-tool-window.html) on the right (default), and find the `runClient` under **COMP5541TeamZombieCode > Tasks > forgegraddle runs**. Right-click `runClient` and run the task._


### PR DESCRIPTION
- This PR removes the instructions which enclose the `genEclipseRuns` and `genIntellijRuns` steps because I think these steps are only executed at the initial setup of the project and is irrelevant for the rest of the development phase.

- The documentation pertinent to MDK is also reworded. As I understand, it is only boilerplate code to start the project. 

- As I understand, it is not necessary to install either the Minecraft game or the Forge installer. These packages are are only for the consumers who wish to play our mods. The MDK seems to include an embedded and playable Minecraft instance for the development.